### PR TITLE
✨ [CW-22279] feat: show notificaiton for 9/24 maintenance

### DIFF
--- a/app/[symbol]/TradingPage.tsx
+++ b/app/[symbol]/TradingPage.tsx
@@ -43,9 +43,9 @@ export default function Trading({ params }: { params: { symbol: string } }) {
   // notification
   const [showNotification, setShowNotification] = useState(true);
   
-  const startDate = new Date('2024-08-23T12:00:00+00:00');
-  const endDate = new Date('2024-08-27T07:00:00+00:00');
-  const message = "Futures will be unavailable on August 27th, 2024, from 06:00 to 07:00 AM (UTC) due to a scheduled Orderly upgrade. Please be aware that losses during this period will not be compensated."
+  const startDate = new Date('2024-09-23T12:00:00+00:00');
+  const endDate = new Date('2024-09-24T08:00:00+00:00');
+  const message = "Futures will be unavailable on September 24th, 2024, from 06:00 to 08:00 AM (UTC) due to a scheduled Orderly upgrade. Please be aware that losses during this period will not be compensated."
 
   const handleNotificationClose = () => {
     setShowNotification(false)


### PR DESCRIPTION
as title
 
 **PR Summary by Typo**
------------

 **Summary**

This pull request updates the dates and message of a futures unavailability notification in the TradingPage component, with the new dates being September 23-24, 2024, and the notification no longer appearing after being dismissed.

**Key Points**

- Updated notification dates and message
- Fixed end time for second day
- Disabled reappearance of dismissed notification. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>