### PR TITLE
✨ [CW-22586] feat: show notification view for 10 26 maintance

### DIFF
--- a/app/[symbol]/TradingPage.tsx
+++ b/app/[symbol]/TradingPage.tsx
@@ -43,9 +43,9 @@ export default function Trading({ params }: { params: { symbol: string } }) {
   // notification
   const [showNotification, setShowNotification] = useState(true);
   
-  const startDate = new Date('2024-09-23T12:00:00+00:00');
-  const endDate = new Date('2024-09-24T08:00:00+00:00');
-  const message = "Futures will be unavailable on September 24th, 2024, from 06:00 to 08:00 AM (UTC) due to a scheduled Orderly upgrade. Please be aware that losses during this period will not be compensated."
+  const startDate = new Date('2024-10-26T00:00:00+00:00');
+  const endDate = new Date('2024-10-29T08:00:00+00:00');
+  const message = "Futures will be unavailable on October 29th, 2024, from 06:00 to 08:00 AM (UTC) due to a scheduled Orderly upgrade. Please be aware that losses during this period will not be compensated."
 
   const handleNotificationClose = () => {
     setShowNotification(false)

--- a/app/[symbol]/TradingPage.tsx
+++ b/app/[symbol]/TradingPage.tsx
@@ -43,7 +43,7 @@ export default function Trading({ params }: { params: { symbol: string } }) {
   // notification
   const [showNotification, setShowNotification] = useState(true);
   
-  const startDate = new Date('2024-10-26T00:00:00+00:00');
+  const startDate = new Date('2024-10-25T00:00:00+00:00');
   const endDate = new Date('2024-10-29T08:00:00+00:00');
   const message = "Futures will be unavailable on October 29th, 2024, from 06:00 to 08:00 AM (UTC) due to a scheduled Orderly upgrade. Please be aware that losses during this period will not be compensated."
 


### PR DESCRIPTION
as title
 
 **PR Summary by Typo**
------------

 **Summary**

This pull request updates the notification dates and message in the TradingPage component for a scheduled futures unavailability. New dates are October 26-29, 2024, and the message has been modified accordingly.

**Key Points**

* TradingPage component notification dates updated
* New dates: October 26-29, 2024
* Message modified accordingly 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>