### PR TITLE
feat: display unavailable announcement from 2025-01-23 to 01-26

### DIFF
--- a/app/[symbol]/TradingPage.tsx
+++ b/app/[symbol]/TradingPage.tsx
@@ -43,9 +43,9 @@ export default function Trading({ params }: { params: { symbol: string } }) {
   // notification
   const [showNotification, setShowNotification] = useState(true);
   
-  const startDate = new Date('2024-10-25T00:00:00+00:00');
-  const endDate = new Date('2024-10-29T08:00:00+00:00');
-  const message = "Futures will be unavailable on October 29th, 2024, from 06:00 to 08:00 AM (UTC) due to a scheduled Orderly upgrade. Please be aware that losses during this period will not be compensated."
+  const startDate = new Date('2025-01-23T00:00:00+00:00');
+  const endDate =   new Date('2025-01-26T07:10:00+00:00');
+  const message = "Futures will be unavailable on January 26th, 2025, from 06:00 to 07:10 AM (UTC) due to a scheduled Orderly upgrade. Please be aware that losses during this period will not be compensated."
 
   const handleNotificationClose = () => {
     setShowNotification(false)


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR updates the date and message of the "Futures Unavailable" notification displayed on the trading page.  The notification now pertains to a scheduled Orderly upgrade on January 26th, 2025.

**Key Changes**
- Changed `startDate` to 2025-01-23.
- Changed `endDate` to 2025-01-26.
- Updated the notification `message` with the new date and time (06:00 to 07:10 AM UTC).

**Recommendations**
Ready to merge after verifying the correct date and time are displayed in the notification.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>